### PR TITLE
Refactor Bear markdown handling, layout and styles; improve URL resolution

### DIFF
--- a/src/components/apps/Bear.tsx
+++ b/src/components/apps/Bear.tsx
@@ -126,30 +126,38 @@ const Middlebar = ({ items, cur, setContent }: MiddlebarProps) => {
   );
 };
 
-const getRepoURL = (url: string) => {
-  return url.slice(0, -10) + "/";
+const getContentBaseURL = (url: string) => {
+  const fileIdx = url.lastIndexOf("/");
+  return fileIdx === -1 ? url : url.slice(0, fileIdx + 1);
 };
 
-const fixImageURL = (text: string, contentURL: string): string => {
-  text = text.replace(/&nbsp;/g, "");
-  if (contentURL.indexOf("raw.githubusercontent.com") !== -1) {
-    const repoURL = getRepoURL(contentURL);
+const normalizeMarkdown = (text: string): string => {
+  return text
+    .replace(/&nbsp;/g, " ")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/(p|div|li|h1|h2|h3|h4|h5|h6)>/gi, "$&\n")
+    .replace(/<[^>]+>/g, "");
+};
 
-    const imgReg = /!\[(.*?)\]\((.*?)\)/;
-    const imgRegGlobal = /!\[(.*?)\]\((.*?)\)/g;
-
-    const imgList = text.match(imgRegGlobal);
-
-    if (imgList) {
-      for (const img of imgList) {
-        const imgURL = (img.match(imgReg) as Array<string>)[2];
-        if (imgURL.indexOf("http") !== -1) continue;
-        const newImgURL = repoURL + imgURL;
-        text = text.replace(imgURL, newImgURL);
-      }
-    }
+const resolveMarkdownURL = (url: string, contentURL: string): string => {
+  if (
+    !url ||
+    url.indexOf("http://") === 0 ||
+    url.indexOf("https://") === 0 ||
+    url.indexOf("mailto:") === 0 ||
+    url.indexOf("tel:") === 0 ||
+    url.indexOf("data:") === 0 ||
+    url.indexOf("//") === 0 ||
+    url.indexOf("#") === 0
+  ) {
+    return url;
   }
-  return text;
+
+  if (contentURL.indexOf("raw.githubusercontent.com") !== -1) {
+    return new URL(url, getContentBaseURL(contentURL)).toString();
+  }
+
+  return url;
 };
 
 const Content = ({ contentID, contentURL }: ContentProps) => {
@@ -162,8 +170,10 @@ const Content = ({ contentID, contentURL }: ContentProps) => {
         fetch(url)
           .then((response) => response.text())
           .then((text) => {
-            storeMd[id] = fixImageURL(text, url);
-            setStoreMd({ ...storeMd });
+            setStoreMd((prev) => ({
+              ...prev,
+              [id]: normalizeMarkdown(text)
+            }));
           })
           .catch((error) => console.error(error));
       }
@@ -177,9 +187,10 @@ const Content = ({ contentID, contentURL }: ContentProps) => {
 
   return (
     <div className="markdown w-full h-full bg-gray-50 text-gray-700 dark:(bg-gray-800 text-gray-200) overflow-scroll py-6">
-      <div className="w-2/3 px-2 mx-auto">
+      <div className="w-full max-w-4xl px-6 mx-auto">
         <ReactMarkdown
           remarkPlugins={[gfm]}
+          urlTransform={(url) => resolveMarkdownURL(url, contentURL)}
           components={{
             a: ({ ...props }) => (
               <a {...props} target="_blank" rel="noreferrer" />

--- a/src/configs/apps.tsx
+++ b/src/configs/apps.tsx
@@ -18,7 +18,7 @@ const apps: AppsData[] = [
     title: "Bear",
     desktop: true,
     show: true,
-    width: 860,
+    width: 980,
     height: 500,
     img: "img/icons/bear.png",
     content: <Bear />

--- a/src/styles/bear.css
+++ b/src/styles/bear.css
@@ -60,7 +60,7 @@
 }
 
 .bear .markdown p {
-  @apply mt-6;
+  @apply mt-6 leading-relaxed break-words;
 }
 
 .bear .markdown h2 + p,
@@ -91,11 +91,11 @@
 }
 
 .bear .markdown code {
-  @apply text-sm border border-gray-300 rounded py-0.5 px-1 bg-gray-50;
+  @apply text-sm border border-gray-300 rounded py-0.5 px-1 bg-gray-50 break-words;
 }
 
 .bear .markdown pre {
-  @apply mt-2 text-sm;
+  @apply mt-2 text-sm overflow-x-auto;
 }
 
 .bear .markdown pre code {
@@ -111,7 +111,7 @@
 }
 
 .bear .markdown img {
-  @apply inline-block;
+  @apply inline-block max-w-full h-auto;
 }
 
 .bear .markdown table {


### PR DESCRIPTION
### Motivation
- Simplify and harden markdown fetching and URL resolution logic for the Bear app to better handle relative asset links and HTML artifacts.
- Improve layout and sizing of the Bear app container to better fit content and the app window.
- Enhance markdown styling to improve wrapping, code blocks, images and horizontal scrolling for long content.

### Description
- Replaced `getRepoURL`/`fixImageURL` with `getContentBaseURL`, `normalizeMarkdown`, and `resolveMarkdownURL` to normalize HTML artifacts and resolve relative URLs, including support for `raw.githubusercontent.com` via `new URL(..., base)` logic.
- Updated markdown fetch flow to store normalized markdown using the functional `setStoreMd` updater and removed the old manual image-replacement regexp logic.
- Passed `urlTransform` to `ReactMarkdown` to resolve resource URLs at render time and changed the markdown container from `w-2/3 px-2` to `w-full max-w-4xl px-6` for better layout.
- Increased the default Bear app `width` from `860` to `980` and adjusted styles in `src/styles/bear.css` to add `leading-relaxed`, `break-words` for paragraphs and code, `overflow-x-auto` for `pre`, and `max-w-full h-auto` for images.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d62f4acba0832ba4a3f63a0bc8d6ef)